### PR TITLE
Refine room inventory extraction and interactive mind-map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+.venv/
+models/
+outputs/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,87 @@
-# bogza-rag-codex-web01
+# Room Inventory Extractor
+
+A minimal local workflow for scanning architectural drawing PDFs, extracting finish and furniture references for specific rooms, and producing both a YAML schedule and an interactive mind-map.
+
+## Highlights
+
+- Works entirely offline with a quantised TinyLlama local model.
+- Handles batches of 10–100 PDFs with automatic text extraction and OCR fallback (Tesseract).
+- Produces a clean YAML file (`room_inventory.yaml`) and an interactive HTML mind-map (`room_inventory.html`).
+- Designed for Windows 10/11 or Linux with 16 GB RAM.
+- One-command install, one-command run.
+
+## Prerequisites
+
+- Python 3.10+
+- Tesseract OCR (optional but recommended for scanned drawings).
+  - Windows: install from [UB Mannheim builds](https://github.com/UB-Mannheim/tesseract/wiki).
+  - Linux: `sudo apt-get install tesseract-ocr`.
+
+## Quick start
+
+```bash
+# 1. Install dependencies and download the default TinyLlama model
+./install.sh
+
+# 2. Copy and edit the configuration
+cp config.example.yaml config.yaml
+# Edit pdf_dir, rooms, and output_dir to match your project
+
+# 3. Run the extractor
+./run.sh
+```
+
+On Windows PowerShell use:
+
+```powershell
+# Install
+./install.ps1
+# Run
+./run.ps1
+```
+
+Both scripts accept the same optional CLI overrides exposed by `python -m room_extractor`. Example:
+
+```bash
+./run.sh --rooms "Room 101" "Room 203" --max-pages 10
+```
+
+## Configuration (`config.yaml`)
+
+| Key | Description |
+| --- | --- |
+| `pdf_dir` | Folder containing 10–100 PDF drawing files. Subdirectories are scanned automatically. |
+| `rooms` | List of room names to analyse. You can re-run the pipeline with a different list at any time. |
+| `model_path` | Path to a local GGUF model (default TinyLlama chat model). |
+| `output_dir` | Folder where YAML/HTML artefacts are written. |
+| `max_pages` | Optional limit of pages per PDF for faster debugging. |
+| `ctx_size`, `temperature`, `top_p`, `n_threads`, `n_gpu_layers` | Advanced knobs for llama.cpp runtime. |
+
+## Outputs
+
+- `room_inventory.yaml`: Structured data ready for Excel/Notion with four categories (Floor, Walls, Ceiling, Furniture). Each line follows `item-code → description → PDF source → product URL`.
+- `room_inventory.html`: Interactive mind-map. Each room renders as a central node with four radial branches (Floor, Walls, Ceiling, Furniture). Click a branch to reveal its leaves and hover over any leaf to see the description, drawing references, and product URL.
+- Console output summarises how many PDFs and pages were processed plus how many pages actually referenced the requested rooms.
+
+## How it works
+
+1. **Text capture** – Vector text is extracted via `pdfplumber`. Low-text pages automatically fall back to OCR with `pytesseract`.
+2. **LLM extraction** – A TinyLlama chat model (through `llama_cpp`) reviews every page that mentions one of the target rooms. The model outputs only verifiable items that include a product URL.
+3. **Validation & aggregation** – Items are cross-checked against the original page text, grouped by room/category, and de-duplicated while retaining all referenced pages/details.
+4. **Reporting** – YAML is emitted for downstream tools. The HTML mind-map renders a radial diagram per room with hoverable leaves. Both artefacts are generated locally with no external dependencies.
+
+## Extending
+
+- Swap the model by editing `config.yaml` with a different GGUF checkpoint.
+- Adjust prompt logic in `room_extractor/llm.py` or post-processing in `room_extractor/postprocess.py` to fit project-specific coding standards.
+- Add alternative OCR or vector parsing by modifying `room_extractor/pdf_processing.py`.
+
+## Troubleshooting
+
+- If OCR is missing, install Tesseract and ensure it is in your system PATH.
+- To inspect raw model output, temporarily insert a `print()` inside `LocalLLM.extract_items`.
+- For GPU acceleration set `n_gpu_layers` in `config.yaml` (requires llama-cpp built with CUDA/Metal).
+
+## License
+
+This project is released under the MIT license.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,9 @@
+pdf_dir: ./pdfs
+rooms:
+  - "Room 101"
+model_path: ./models/TinyLlama-1.1B-Chat-q4_k_m.gguf
+output_dir: ./outputs
+ctx_size: 2048
+temperature: 0.05
+top_p: 0.15
+max_pages: null

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,5 @@
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install --upgrade pip
+pip install -r requirements.txt
+python scripts/fetch_model.py --output models/TinyLlama-1.1B-Chat-q4_k_m.gguf

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+python scripts/fetch_model.py --output models/TinyLlama-1.1B-Chat-q4_k_m.gguf

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+llama-cpp-python==0.2.63
+pdfplumber==0.11.4
+pypdfium2==4.24.0
+pillow==10.3.0
+pytesseract==0.3.10
+PyYAML==6.0.1
+numpy==1.26.4

--- a/room_extractor/__main__.py
+++ b/room_extractor/__main__.py
@@ -1,0 +1,10 @@
+from .cli import Config, run
+
+
+def main() -> None:
+    cfg = Config.from_args()
+    run(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/room_extractor/cli.py
+++ b/room_extractor/cli.py
@@ -1,0 +1,181 @@
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+
+import yaml
+
+from .llm import LocalLLM
+from .pdf_processing import extract_pdf_pages
+from .postprocess import build_mindmap_html, normalise_item
+
+
+CATEGORY_MAP = {
+    "FLOOR": "Floor",
+    "WALL": "Walls",
+    "WALLS": "Walls",
+    "CEILING": "Ceiling",
+    "FURNITURE": "Furniture",
+    "CASEWORK": "Furniture",
+    "EQUIPMENT": "Furniture",
+}
+
+
+@dataclass
+class Config:
+    pdf_dir: Path
+    rooms: List[str]
+    model_path: Path
+    output_dir: Path
+    max_pages: Optional[int] = None
+    temperature: float = 0.1
+    top_p: float = 0.15
+    ctx_size: int = 2048
+    n_threads: Optional[int] = None
+    n_gpu_layers: int = 0
+
+    @staticmethod
+    def from_args() -> "Config":
+        parser = argparse.ArgumentParser(description="Extract finishes and furniture data from architectural PDFs.")
+        parser.add_argument("--config", type=Path, help="Path to YAML configuration file.")
+        parser.add_argument("--rooms", nargs="*", help="Override rooms defined in the config file.")
+        parser.add_argument("--pdf-dir", type=Path, help="Override PDF directory.", dest="pdf_dir")
+        parser.add_argument("--model-path", type=Path, help="Override local GGUF model path.", dest="model_path")
+        parser.add_argument("--output-dir", type=Path, help="Override output directory.", dest="output_dir")
+        parser.add_argument("--max-pages", type=int, help="Maximum pages to read per PDF.")
+        args = parser.parse_args()
+
+        if not args.config:
+            raise SystemExit("Configuration file (--config) is required.")
+        with args.config.open("r", encoding="utf-8") as fh:
+            payload = yaml.safe_load(fh) or {}
+
+        def _override(key, attr=None):
+            value = getattr(args, attr or key, None)
+            if value is not None:
+                payload[key] = value
+
+        _override("pdf_dir")
+        _override("model_path")
+        _override("output_dir")
+        if args.rooms:
+            payload["rooms"] = args.rooms
+        if args.max_pages is not None:
+            payload["max_pages"] = args.max_pages
+
+        missing = [k for k in ("pdf_dir", "rooms", "model_path", "output_dir") if k not in payload]
+        if missing:
+            raise SystemExit(f"Missing configuration values: {', '.join(missing)}")
+
+        return Config(
+            pdf_dir=Path(payload["pdf_dir"]).expanduser().resolve(),
+            rooms=[str(r) for r in payload.get("rooms", [])],
+            model_path=Path(payload["model_path"]).expanduser().resolve(),
+            output_dir=Path(payload["output_dir"]).expanduser().resolve(),
+            max_pages=payload.get("max_pages"),
+            temperature=float(payload.get("temperature", 0.1)),
+            top_p=float(payload.get("top_p", 0.15)),
+            ctx_size=int(payload.get("ctx_size", 2048)),
+            n_threads=payload.get("n_threads"),
+            n_gpu_layers=int(payload.get("n_gpu_layers", 0)),
+        )
+
+
+def run(config: Config) -> None:
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+
+    llm = LocalLLM(
+        model_path=config.model_path,
+        temperature=config.temperature,
+        top_p=config.top_p,
+        ctx_size=config.ctx_size,
+        n_threads=config.n_threads,
+        n_gpu_layers=config.n_gpu_layers,
+    )
+
+    room_data, stats = collect_room_data(
+        rooms=config.rooms,
+        pages=extract_pdf_pages(config.pdf_dir, config.max_pages),
+        llm=llm,
+    )
+
+    if not any(room_data[room][category] for room in room_data for category in room_data[room]):
+        print("No qualifying items were found for the requested rooms.")
+
+    yaml_path = config.output_dir / "room_inventory.yaml"
+    with yaml_path.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(format_yaml_payload(room_data), fh, sort_keys=False, allow_unicode=True)
+
+    html_path = config.output_dir / "room_inventory.html"
+    html_content = build_mindmap_html(room_data)
+    html_path.write_text(html_content, encoding="utf-8")
+
+    print(f"Processed {stats['pages_total']} pages across {stats['pdf_count']} PDFs.")
+    print(f"Pages mentioning target rooms: {stats['pages_with_hits']}.")
+    print(f"YAML saved to {yaml_path}")
+    print(f"Mind map saved to {html_path}")
+
+
+def collect_room_data(
+    *,
+    rooms: Iterable[str],
+    pages: Iterable[Tuple[Path, int, str]],
+    llm: LocalLLM,
+) -> Tuple[Dict[str, Dict[str, Dict[Tuple[str, str], Dict[str, Set[str]]]]], Dict[str, int]]:
+    rooms = list(rooms)
+    room_data: Dict[str, Dict[str, Dict[Tuple[str, str], Dict[str, Set[str]]]]] = {
+        room: {"Floor": {}, "Walls": {}, "Ceiling": {}, "Furniture": {}} for room in rooms
+    }
+    stats = {"pages_total": 0, "pages_with_hits": 0, "pdf_count": 0}
+    current_pdf: Optional[Path] = None
+
+    for pdf_path, page_number, text in pages:
+        if current_pdf != pdf_path:
+            stats["pdf_count"] += 1
+            current_pdf = pdf_path
+        stats["pages_total"] += 1
+        if not text:
+            continue
+        text_lower = text.lower()
+        page_had_room = False
+        for room in rooms:
+            if room.lower() not in text_lower:
+                continue
+            page_had_room = True
+            for raw in llm.extract_items(room, text):
+                category_key = CATEGORY_MAP.get(raw.category.upper())
+                if not category_key:
+                    continue
+                cleaned = normalise_item(text, raw)
+                if not cleaned:
+                    continue
+                item_code, description = cleaned
+                key = (item_code, raw.url)
+                bucket = room_data[room][category_key]
+                record = bucket.setdefault(key, {"description": description, "sources": set()})
+                detail_suffix = f"; {raw.detail}" if raw.detail else ""
+                record["sources"].add(f"{pdf_path.name} p.{page_number}{detail_suffix}")
+        if page_had_room:
+            stats["pages_with_hits"] += 1
+
+    return room_data, stats
+
+
+def format_yaml_payload(room_data):
+    payload = {}
+    for room, categories in room_data.items():
+        payload[room] = {}
+        for category, items in categories.items():
+            entries = []
+            for (item_code, url), record in sorted(items.items(), key=lambda x: x[0][0]):
+                sources = sorted(record["sources"])
+                source_text = ", ".join(sources)
+                entries.append(f"{item_code} → {record['description']} → {source_text} → {url}")
+            if entries:
+                payload[room][category] = entries
+    return payload
+
+
+if __name__ == "__main__":
+    cfg = Config.from_args()
+    run(cfg)

--- a/room_extractor/llm.py
+++ b/room_extractor/llm.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+from llama_cpp import Llama
+
+
+PROMPT_TEMPLATE = '''
+You analyse architectural drawing schedules. Work only with the evidence from the given text.
+Room of interest: {room}
+
+Return zero or more lines. Each line must follow this format exactly (no commentary before or after):
+CATEGORY|ITEM_CODE|SHORT_DESCRIPTION|SOURCE_NOTE|PRODUCT_URL
+
+Rules:
+- CATEGORY must be one of FLOOR, WALLS, CEILING, FURNITURE, CASEWORK, EQUIPMENT.
+- ITEM_CODE must be copied exactly as written in the text. If there is no code, leave the field empty but keep the separators.
+- SHORT_DESCRIPTION must stay under 12 words and only summarise the item or finish.
+- SOURCE_NOTE should capture the detail/elevation/schedule reference that identifies the associated drawing or figure. Leave empty if the text does not include one.
+- PRODUCT_URL must be a URL that appears in the text. If there is no URL in the text related to the item, do not output that line.
+- Only report data that clearly refers to the specified room. If uncertain, skip it.
+- Do not invent new information. If the text does not mention any qualifying item, return nothing.
+
+Text:
+"""{page_text}"""
+'''
+
+LINE_PATTERN = re.compile(
+    r"^(?P<category>[A-Z ]+)\|(?P<item_code>[^|]*)\|(?P<description>[^|]{1,256})\|(?P<detail>[^|]{0,200})\|(?P<url>https?://\S+)$"
+)
+
+
+@dataclass
+class Extraction:
+    category: str
+    item_code: str
+    description: str
+    detail: str
+    url: str
+
+
+class LocalLLM:
+    def __init__(
+        self,
+        model_path,
+        temperature: float = 0.1,
+        top_p: float = 0.15,
+        ctx_size: int = 2048,
+        n_threads: Optional[int] = None,
+        n_gpu_layers: int = 0,
+    ) -> None:
+        kwargs = {
+            "model_path": str(model_path),
+            "n_ctx": ctx_size,
+            "temperature": temperature,
+            "top_p": top_p,
+            "n_gpu_layers": n_gpu_layers,
+        }
+        if n_threads is not None:
+            kwargs["n_threads"] = n_threads
+        self.client = Llama(**kwargs)
+        self.temperature = temperature
+        self.top_p = top_p
+
+    def extract_items(self, room: str, page_text: str) -> List[Extraction]:
+        snippet = page_text.strip()
+        if len(snippet) > 6000:
+            snippet = snippet[:6000]
+        prompt = PROMPT_TEMPLATE.format(room=room, page_text=snippet)
+        response = self.client.create_completion(
+            prompt=prompt,
+            max_tokens=512,
+            temperature=self.temperature,
+            top_p=self.top_p,
+            stop=["\n\n"],
+        )
+        text = response["choices"][0]["text"]
+        return list(self._parse(text))
+
+    @staticmethod
+    def _parse(text: str) -> Iterable[Extraction]:
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            match = LINE_PATTERN.match(line)
+            if not match:
+                continue
+            info = match.groupdict()
+            yield Extraction(
+                category=info["category"].strip(),
+                item_code=info["item_code"].strip(),
+                description=info["description"].strip(),
+                detail=info["detail"].strip(),
+                url=info["url"].strip(),
+            )

--- a/room_extractor/pdf_processing.py
+++ b/room_extractor/pdf_processing.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import itertools
+from pathlib import Path
+from typing import Iterable, Iterator, Tuple
+
+import pdfplumber
+
+
+def extract_pdf_pages(pdf_dir: Path, max_pages: int | None = None) -> Iterator[Tuple[Path, int, str]]:
+    pdf_paths = sorted(
+        [p for p in pdf_dir.rglob("*.pdf") if p.is_file()],
+        key=lambda p: (str(p.parent), p.name),
+    )
+    for pdf_path in pdf_paths:
+        with pdfplumber.open(pdf_path) as pdf:
+            for index, page in enumerate(pdf.pages, start=1):
+                if max_pages is not None and index > max_pages:
+                    break
+                text = page.extract_text(x_tolerance=1.5, y_tolerance=1.5)
+                if text:
+                    text = text.strip()
+                if not text:
+                    text = _ocr_page(page)
+                yield pdf_path, index, text or ""
+
+
+def _ocr_page(page) -> str:
+    try:
+        import numpy as np  # noqa: F401
+        from PIL import Image
+        import pytesseract
+    except Exception:
+        return ""
+
+    try:
+        page_image = page.to_image(resolution=300)
+        pil_image = Image.fromarray(page_image.original)
+        text = pytesseract.image_to_string(pil_image, config="--psm 6")
+        return text.strip()
+    except Exception:
+        return ""

--- a/room_extractor/postprocess.py
+++ b/room_extractor/postprocess.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Dict, Iterable, Optional, Tuple
+
+from .llm import Extraction
+
+
+_NON_CODE_CHARS = re.compile(r"[^a-z0-9]")
+
+
+def _normalise_token(value: str) -> str:
+    return _NON_CODE_CHARS.sub("", value.lower())
+
+
+def normalise_item(page_text: str, item: Extraction) -> Optional[Tuple[str, str]]:
+    """Validate an extracted item against the page text.
+
+    The LLM may occasionally hallucinate codes or URLs. We only accept an item when
+    both the URL and the item code can be located in the source text (ignoring
+    punctuation differences) and the description is non-empty.
+    """
+
+    if not item.url or not item.item_code:
+        return None
+
+    text_normalised = _normalise_token(page_text)
+    if _normalise_token(item.url) not in text_normalised:
+        return None
+
+    item_code = item.item_code.strip()
+    if not item_code:
+        return None
+    if _normalise_token(item_code) not in text_normalised:
+        return None
+
+    description = item.description.strip()
+    if not description:
+        return None
+    return item_code, description
+
+
+def _serialise_room_data(room_data: Dict[str, Dict[str, Dict]]) -> Dict[str, Dict[str, Iterable[Dict[str, object]]]]:
+    serialised: Dict[str, Dict[str, Iterable[Dict[str, object]]]] = {}
+    for room, categories in room_data.items():
+        serialised[room] = {}
+        for category, items in categories.items():
+            entries = []
+            for (item_code, url), record in sorted(items.items(), key=lambda x: x[0][0]):
+                entries.append(
+                    {
+                        "item_code": item_code,
+                        "description": record["description"],
+                        "sources": sorted(record["sources"]),
+                        "url": url,
+                    }
+                )
+            if entries:
+                serialised[room][category] = entries
+    return serialised
+
+
+def build_mindmap_html(room_data: Dict[str, Dict[str, Dict]]) -> str:
+    """Create an interactive SVG mind-map visualisation.
+
+    The output keeps every room as an isolated mind-map: a central node with four
+    branches (Floor, Walls, Ceiling, Furniture). Clicking a branch toggles its
+    leaves. No external libraries or network calls are required.
+    """
+
+    serialised = _serialise_room_data(room_data)
+    data_json = json.dumps(serialised)
+
+    template = """<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+<meta charset=\"utf-8\" />
+<title>Room Inventory Mind Map</title>
+<style>
+body {
+    font-family: 'Segoe UI', Roboto, sans-serif;
+    background: #0f172a;
+    color: #e2e8f0;
+    margin: 0;
+    padding: 2rem;
+}
+h1 {
+    text-align: center;
+    margin-bottom: 2rem;
+}
+.room-container {
+    margin: 0 auto 3rem auto;
+    max-width: 960px;
+    background: rgba(15, 23, 42, 0.45);
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    border-radius: 18px;
+    padding: 1.5rem;
+    box-shadow: 0 35px 60px rgba(15, 23, 42, 0.45);
+}
+.room-title {
+    text-align: center;
+    font-size: 1.75rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+}
+.mindmap {
+    width: 100%;
+    height: 520px;
+}
+.legend {
+    margin-top: 1.5rem;
+    font-size: 0.85rem;
+    color: #cbd5f5;
+}
+svg {
+    width: 100%;
+    height: 100%;
+}
+.node text {
+    font-size: 0.85rem;
+    pointer-events: none;
+}
+.node circle {
+    fill: #1d4ed8;
+    stroke: #60a5fa;
+    stroke-width: 2;
+    cursor: pointer;
+}
+.leaf circle {
+    fill: #10b981;
+    stroke: #6ee7b7;
+}
+.leaf text {
+    fill: #ecfeff;
+}
+.branch circle {
+    fill: #9333ea;
+    stroke: #c084fc;
+}
+.branch text {
+    fill: #f5f3ff;
+}
+.room circle {
+    fill: #fbbf24;
+    stroke: #fde68a;
+}
+.room text {
+    fill: #0f172a;
+    font-weight: 600;
+}
+.hidden {
+    display: none;
+}
+.tooltip {
+    position: absolute;
+    background: rgba(15, 23, 42, 0.92);
+    color: #f8fafc;
+    padding: 0.45rem 0.65rem;
+    border-radius: 8px;
+    font-size: 0.8rem;
+    pointer-events: none;
+    max-width: 260px;
+    box-shadow: 0 12px 32px rgba(15, 23, 42, 0.45);
+    z-index: 10;
+}
+.tooltip a {
+    color: #60a5fa;
+}
+</style>
+</head>
+<body>
+<h1>Room Inventory Mind Maps</h1>
+<div id=\"container\"></div>
+<div class=\"tooltip hidden\" id=\"tooltip\"></div>
+<script>
+const data = __ROOM_DATA__;
+
+const CATEGORY_ANGLES = {
+    'Floor': -Math.PI / 2,
+    'Walls': -Math.PI / 6,
+    'Ceiling': Math.PI / 6,
+    'Furniture': Math.PI / 2,
+};
+
+const CATEGORY_COLORS = {
+    'Floor': '#38bdf8',
+    'Walls': '#f472b6',
+    'Ceiling': '#facc15',
+    'Furniture': '#34d399'
+};
+
+function polarToCartesian(cx, cy, radius, angle) {
+    return [
+        cx + radius * Math.cos(angle),
+        cy + radius * Math.sin(angle)
+    ];
+}
+
+function createRoom(section, room, categories) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'room-container';
+
+    const title = document.createElement('div');
+    title.className = 'room-title';
+    title.textContent = room;
+    wrapper.appendChild(title);
+
+    const mindmap = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    mindmap.classList.add('mindmap');
+    wrapper.appendChild(mindmap);
+
+    const tooltip = document.getElementById('tooltip');
+
+    const width = mindmap.clientWidth || 900;
+    const height = mindmap.clientHeight || 520;
+    const centre = [width / 2, height / 2];
+    const branchRadius = Math.min(width, height) / 3.5;
+
+    function addCircle(x, y, radius, cls, label) {
+        const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        g.classList.add('node');
+        if (cls) g.classList.add(cls);
+
+        const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        circle.setAttribute('cx', x);
+        circle.setAttribute('cy', y);
+        circle.setAttribute('r', radius);
+        g.appendChild(circle);
+
+        const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        text.setAttribute('x', x);
+        text.setAttribute('y', y + 4);
+        text.setAttribute('text-anchor', 'middle');
+        text.textContent = label;
+        g.appendChild(text);
+
+        mindmap.appendChild(g);
+        return g;
+    }
+
+    function addLine(x1, y1, x2, y2, color, width = 2) {
+        const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+        line.setAttribute('x1', x1);
+        line.setAttribute('y1', y1);
+        line.setAttribute('x2', x2);
+        line.setAttribute('y2', y2);
+        line.setAttribute('stroke', color);
+        line.setAttribute('stroke-width', width);
+        mindmap.appendChild(line);
+        return line;
+    }
+
+    const [cx, cy] = centre;
+    addCircle(cx, cy, 40, 'room', room);
+
+    const orderedCategories = ['Floor', 'Walls', 'Ceiling', 'Furniture'];
+    orderedCategories.forEach((category) => {
+        const entries = categories[category] || [];
+        if (!entries.length) return;
+
+        const angle = CATEGORY_ANGLES[category] ?? Math.random() * 2 * Math.PI;
+        const [bx, by] = polarToCartesian(cx, cy, branchRadius, angle);
+        addLine(cx, cy, bx, by, CATEGORY_COLORS[category] || '#94a3b8', 3);
+        const branchNode = addCircle(bx, by, 26, 'branch', category);
+
+        branchNode.querySelector('circle').style.fill = CATEGORY_COLORS[category] || '#94a3b8';
+
+        let expanded = false;
+        const leafLines = [];
+        const leafNodes = [];
+
+        const perLeafSpacing = 56;
+        const startRadius = branchRadius + 60;
+
+        entries.forEach((entry, index) => {
+            const leafRadius = startRadius + perLeafSpacing * index;
+            const [lx, ly] = polarToCartesian(cx, cy, leafRadius, angle);
+            const line = addLine(bx, by, lx, ly, CATEGORY_COLORS[category] || '#94a3b8', 1.8);
+            const leaf = addCircle(lx, ly, 18, 'leaf', entry.item_code);
+            leaf.classList.add('hidden');
+            line.classList.add('hidden');
+
+            leafLines.push(line);
+            leafNodes.push({ leaf, entry });
+
+            leaf.addEventListener('mouseover', (event) => {
+                tooltip.classList.remove('hidden');
+                const [px, py] = [event.pageX + 12, event.pageY + 12];
+                tooltip.style.left = px + 'px';
+                tooltip.style.top = py + 'px';
+                tooltip.innerHTML = `
+                    <strong>${entry.item_code}</strong><br />
+                    ${entry.description}<br />
+                    <em>${entry.sources.join(', ')}</em><br />
+                    <a href="${entry.url}" target="_blank">${entry.url}</a>
+                `;
+            });
+
+            leaf.addEventListener('mouseout', () => {
+                tooltip.classList.add('hidden');
+            });
+        });
+
+        const toggleLeaves = () => {
+            expanded = !expanded;
+            leafLines.forEach(line => line.classList.toggle('hidden', !expanded));
+            leafNodes.forEach(({ leaf, entry }) => {
+                leaf.classList.toggle('hidden', !expanded);
+                const circle = leaf.querySelector('circle');
+                const text = leaf.querySelector('text');
+                if (circle) circle.style.fill = CATEGORY_COLORS[category] || '#38bdf8';
+                if (text) text.textContent = entry.item_code;
+            });
+        };
+
+        branchNode.addEventListener('click', toggleLeaves);
+    });
+
+    const legend = document.createElement('div');
+    legend.className = 'legend';
+    legend.textContent = 'Click a branch to reveal item leaves. Hover a leaf to view description, sources, and product link.';
+    wrapper.appendChild(legend);
+
+    section.appendChild(wrapper);
+}
+
+const container = document.getElementById('container');
+Object.entries(data).forEach(([room, categories]) => {
+    if (!Object.keys(categories).length) return;
+    createRoom(container, room, categories);
+});
+
+if (!container.children.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No qualifying items were extracted.';
+    container.appendChild(empty);
+}
+</script>
+</body>
+</html>
+"""
+
+    return template.replace("__ROOM_DATA__", data_json)
+
+
+__all__ = ["build_mindmap_html", "normalise_item"]

--- a/run.ps1
+++ b/run.ps1
@@ -1,0 +1,2 @@
+.\.venv\Scripts\Activate.ps1
+python -m room_extractor --config config.yaml $args

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source .venv/bin/activate
+python -m room_extractor --config config.yaml "$@"

--- a/scripts/fetch_model.py
+++ b/scripts/fetch_model.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+from urllib.request import urlopen
+
+BUFFER_SIZE = 1024 * 1024
+MODEL_URL = "https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/TinyLlama-1.1B-Chat-v1.0-q4_k_m.gguf?download=1"
+EXPECTED_SHA256 = "50c06cbd2d51b400ebd5af4c7cb3f7023bf67b7e20e5c662cf4d34850f9c1925"
+
+
+def download_model(target: Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        print(f"Model already exists at {target}")
+        return
+    print(f"Downloading TinyLlama model to {target} ...")
+    response = urlopen(MODEL_URL)
+    hasher = hashlib.sha256()
+    with target.open("wb") as fh:
+        while True:
+            chunk = response.read(BUFFER_SIZE)
+            if not chunk:
+                break
+            fh.write(chunk)
+            hasher.update(chunk)
+    digest = hasher.hexdigest()
+    if digest != EXPECTED_SHA256:
+        target.unlink(missing_ok=True)
+        raise SystemExit(f"Checksum mismatch for model: expected {EXPECTED_SHA256}, got {digest}")
+    print("Model download complete.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download the default TinyLlama GGUF model.")
+    parser.add_argument("--output", type=Path, default=Path("models/TinyLlama-1.1B-Chat-q4_k_m.gguf"))
+    args = parser.parse_args()
+    download_model(args.output.resolve())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a reusable room aggregation helper that reports processed PDF/page counts for the CLI
- harden post-processing validation and ship a radial interactive SVG mind-map for the inventory
- document the enhanced HTML output and runtime statistics in the README

## Testing
- python -m compileall room_extractor scripts

------
https://chatgpt.com/codex/tasks/task_e_68dd82083cf8832da4c78e3cd83f2035